### PR TITLE
Make clockSpeed unsigned long to avoid truncation

### DIFF
--- a/AD5933.h
+++ b/AD5933.h
@@ -138,7 +138,7 @@ class AD5933 {
                               int imag[], int ref, int n);
     private:
         // Private data
-        static const unsigned int clockSpeed = 16776000;
+        static const unsigned long clockSpeed = 16776000;
 
         // Sending/Receiving byte method, for easy re-use
         static int getByte(byte, byte*);


### PR DESCRIPTION
Arduino IDE gives the error "large integer implicitly truncated to unsigned type" and the clockSpeed ends up truncated, triggered the return False in AD5933.h line 206 setStartFrequency because freqHex ends up larger than 0xFFFFFF. Thus we end up with the error "FAILED in initialization!"

Changing clockSpeed to unsigned long prevents truncation and the library works.