### PR TITLE
`calibrate()` function overflows if reference resistance is big (e.g. 10kOhm)

### DIFF
--- a/AD5933.cpp
+++ b/AD5933.cpp
@@ -514,7 +514,7 @@ bool AD5933::frequencySweep(int real[], int imag[], int n) {
  * @param n Length of the array (or the number of discrete measurements)
  * @return Success or failure
  */
-bool AD5933::calibrate(double gain[], int phase[], int ref, int n) {
+bool AD5933::calibrate(double gain[], int phase[], long ref, int n) {
     // We need arrays to hold the real and imaginary values temporarily
     int *real = new int[n];
     int *imag = new int[n];
@@ -550,7 +550,7 @@ bool AD5933::calibrate(double gain[], int phase[], int ref, int n) {
  * @return Success or failure
  */
 bool AD5933::calibrate(double gain[], int phase[], int real[], int imag[],
-                       int ref, int n) {
+                       long ref, int n) {
     // Perform the frequency sweep
     if (!frequencySweep(real, imag, n)) {
         return false;

--- a/AD5933.h
+++ b/AD5933.h
@@ -138,9 +138,9 @@ class AD5933 {
 
         // Perform frequency sweeps
         static bool frequencySweep(int real[], int imag[], int);
-        static bool calibrate(double gain[], int phase[], int ref, int n);
+        static bool calibrate(double gain[], int phase[], long ref, int n);
         static bool calibrate(double gain[], int phase[], int real[],
-                              int imag[], int ref, int n);
+                              int imag[], long ref, int n);
     private:
         // Private data
         static const unsigned long clockSpeed = 16776000;


### PR DESCRIPTION
- `referenceResistor` in `calibrate()` function has type of `int`, and this cause overflow if R > 32767 Ohm.
- I changed it to `long` type.
