### PR TITLE
`setRange()` function should be static

### DIFF
--- a/AD5933.h
+++ b/AD5933.h
@@ -120,7 +120,7 @@ class AD5933 {
         static bool setPGAGain(byte);
 
         // Excitation range configuration
-        bool setRange(byte);
+        static bool setRange(byte);
 
         // Read registers
         static byte readRegister(byte);


### PR DESCRIPTION
- All common functions are static, so I think `setRange()` function also should be static.